### PR TITLE
Error if no source_dir_purge option is set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -253,8 +253,8 @@ class nginx (
 
   ### Calculation of variables that dependes on arguments
   $vdir = $::operatingsystem ? {
-    /(?i:Ubuntu|Debian|Mint)/              => "${nginx::config_dir}/sites-available",
-   default                                 => "${nginx::config_dir}/conf.d",
+    /(?i:Ubuntu|Debian|Mint)/ => "${nginx::config_dir}/sites-available",
+    default                   => "${nginx::config_dir}/conf.d",
   }
 
   ### Definition of some variables used in the module
@@ -292,7 +292,9 @@ class nginx (
     default => 'present',
   }
 
-  if $nginx::bool_absent == true or $nginx::bool_disable == true or $nginx::bool_disableboot == true {
+  if $nginx::bool_absent == true
+  or $nginx::bool_disable == true
+  or $nginx::bool_disableboot == true {
     $manage_monitor = false
   } else {
     $manage_monitor = true
@@ -362,7 +364,7 @@ class nginx (
       notify  => $nginx::manage_service_autorestart,
       source  => $nginx::source_dir,
       recurse => true,
-      purge   => $nginx::source_dir_purge,
+      purge   => $bool_source_dir_purge,
       replace => $nginx::manage_file_replace,
       audit   => $nginx::manage_audit,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,7 +88,7 @@ class nginx::params {
   $my_class = ''
   $source = ''
   $source_dir = ''
-  $source_dir_purge = ''
+  $source_dir_purge = false
   $template = ''
   $options = ''
   $service_autorestart = true


### PR DESCRIPTION
Same as https://github.com/example42/puppet-apache/pull/4 for puppet-nginx

If no source_dir_purge option is set, puppet raise this error
Parameter purge failed: Invalid value "". Valid values are true, false.

This PR use bool_source_dir_purge variable instead of ${apache::source_dir_purge} and set default value for source_dir_purge to false.

Thank's for your work.

Romain
