### PR TITLE
Error: Could not set 'file' on ensure: No such file or directory - /etc/nginx/sites-available/test.example at 62:/tmp/vagrant-puppet/modules-0/nginx/manifests/resource/vhost.pp

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -49,9 +49,10 @@ define nginx::resource::vhost(
 ) {
 
   File {
-    owner => 'root',
-    group => 'root',
-    mode  => '0644',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Package['nginx']
   }
 
   file { "${nginx::config_dir}/sites-available/${name}":


### PR DESCRIPTION
Any objections to this?
