### PR TITLE
Puppet version 3.2.1 has deprecated variable access warnings.

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,6 +1,6 @@
 # File Managed by Puppet 
 user <%= scope.lookupvar('nginx::process_user') %>;
-worker_processes <%= processorcount %>;
+worker_processes <%= @processorcount %>;
 
 error_log  <%= scope.lookupvar('nginx::log_dir')%>/error.log;
 pid        <%= scope.lookupvar('nginx::pid_file')%>;

--- a/templates/conf.d/proxy.conf.erb
+++ b/templates/conf.d/proxy.conf.erb
@@ -6,5 +6,5 @@ proxy_send_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_send_timeou
 proxy_read_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_read_timeout') %>;
 proxy_buffers           <%= scope.lookupvar('nginx::params::nx_proxy_buffers') %>;
 <% scope.lookupvar('nginx::params::nx_proxy_set_header').each do |header| %>
-proxy_set_header        <%= header %>;
+proxy_set_header        <%= @header %>;
 <% end %>

--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -1,5 +1,5 @@
-upstream <%= name %> {
+upstream <%= @name %> {
   <% members.each do |i| %>
-  server <%= i %>;
+  server <%= @i %>;
   <% end %>
 }

--- a/templates/spec.erb
+++ b/templates/spec.erb
@@ -4,5 +4,5 @@
 <%= scope.to_hash.reject { |k,v| !( k.is_a?(String) && v.is_a?(String) ) }.to_yaml %>
 
 # Custom Options
-<%= options['opt_a'] %>
-<%= options['opt_b'] %>
+<%= @options['opt_a'] %>
+<%= @options['opt_b'] %>

--- a/templates/vhost/vhost.conf.erb
+++ b/templates/vhost/vhost.conf.erb
@@ -1,9 +1,9 @@
 # File Managed by Puppet
 
 server {
-  listen <%= port %>; 
-  root  <%= docroot %>;
-  server_name <%= name %> <%= serveraliases %>;
+  listen <%= @port %>; 
+  root  <%= @docroot %>;
+  server_name <%= @name %> <%= @serveraliases %>;
 
   access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= name %>.access.log;
   error_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= name %>.error.log;

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,8 +1,8 @@
 # File Managed by Puppet
 
 server {
-  listen <%= listen_ip %>; 
+  listen <%= @listen_ip %>; 
   <% # check to see if ipv6 support exists in the kernel before applying %>
-  <% if ipv6_enable == 'true' && (defined? ipaddress6) %>listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> default ipv6only=on;<% end %>
-  server_name <%= server_name %>;
-  access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= name %>.access.log;
+  <% if @ipv6_enable == 'true' && (defined? ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
+  server_name <%= @server_name %>;
+  access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= @name %>.access.log;

--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -1,4 +1,4 @@
-  location <%= location %> {
-    root  <%= www_root %>;
-    index <% index_files.each do |i| %> <%= i %> <% end %>; 
+  location <%= @location %> {
+    root  <%= @www_root %>;
+    index <% @index_files.each do |i| %> <%= @i %> <% end %>; 
   }

--- a/templates/vhost/vhost_location_proxy.erb
+++ b/templates/vhost/vhost_location_proxy.erb
@@ -1,8 +1,8 @@
-  location <%= location %> {
-    proxy_pass <%= proxy %>;
-    proxy_read_timeout <%= proxy_read_timeout %>;
-<%  proxy_set_header.each do |header| -%>
-    proxy_set_header        <%= header %>;
+  location <%= @location %> {
+    proxy_pass <%= @proxy %>;
+    proxy_read_timeout <%= @proxy_read_timeout %>;
+<%  @proxy_set_header.each do |header| -%>
+    proxy_set_header        <%= @header %>;
 <%  end %>
   }
 

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,11 +1,11 @@
 server {
   listen       443;
-  <% if ipv6_enable == 'true' && (defined? ipaddress6) %>listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> default ipv6only=on;<% end %>
-  server_name  <%= server_name %>;
+  <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
+  server_name  <%= @server_name %>;
 
   ssl on;
-  ssl_certificate      <%= ssl_cert %>;
-  ssl_certificate_key  <%= ssl_key %>;
+  ssl_certificate      <%= @ssl_cert %>;
+  ssl_certificate_key  <%= @ssl_key %>;
 
   ssl_session_timeout  5m;
 


### PR DESCRIPTION
Removes warnings such as:

Warning: Variable access via 'processorcount' is deprecated. Use '@processorcount' instead.
