### PR TITLE
Some template variables were erroneously using @

### DIFF
--- a/templates/conf.d/proxy.conf.erb
+++ b/templates/conf.d/proxy.conf.erb
@@ -6,5 +6,5 @@ proxy_send_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_send_timeou
 proxy_read_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_read_timeout') %>;
 proxy_buffers           <%= scope.lookupvar('nginx::params::nx_proxy_buffers') %>;
 <% scope.lookupvar('nginx::params::nx_proxy_set_header').each do |header| %>
-proxy_set_header        <%= @header %>;
+proxy_set_header        <%= header %>;
 <% end %>

--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -1,5 +1,5 @@
 upstream <%= @name %> {
-  <% members.each do |i| %>
-  server <%= @i %>;
+  <% @members.each do |i| %>
+  server <%= i %>;
   <% end %>
 }

--- a/templates/vhost/vhost.conf.erb
+++ b/templates/vhost/vhost.conf.erb
@@ -5,7 +5,7 @@ server {
   root  <%= @docroot %>;
   server_name <%= @name %> <%= @serveraliases %>;
 
-  access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= name %>.access.log;
-  error_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= name %>.error.log;
+  access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= @name %>.access.log;
+  error_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= @name %>.error.log;
 
 }

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -3,6 +3,6 @@
 server {
   listen <%= @listen_ip %>; 
   <% # check to see if ipv6 support exists in the kernel before applying %>
-  <% if @ipv6_enable == 'true' && (defined? ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
+  <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
   server_name <%= @server_name %>;
   access_log  <%= scope.lookupvar('nginx::log_dir')%>/<%= @name %>.access.log;

--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -1,4 +1,4 @@
   location <%= @location %> {
     root  <%= @www_root %>;
-    index <% @index_files.each do |i| %> <%= @i %> <% end %>; 
+    index <% @index_files.each do |i| %> <%= i %> <% end %>; 
   }

--- a/templates/vhost/vhost_location_proxy.erb
+++ b/templates/vhost/vhost_location_proxy.erb
@@ -2,7 +2,7 @@
     proxy_pass <%= @proxy %>;
     proxy_read_timeout <%= @proxy_read_timeout %>;
 <%  @proxy_set_header.each do |header| -%>
-    proxy_set_header        <%= @header %>;
+    proxy_set_header        <%= header %>;
 <%  end %>
   }
 


### PR DESCRIPTION
Alessandro,

  AFAIK, "@" should be used in a template to reference variables that are passed from puppet to the template, but not to variables created INSIDE the tempalte (as in loops). Due to this, many of the templates, when parsed, generated empty strings.

This patch corrects that.

Regards, Javier
