### PR TITLE
Add the ability to override nginx::resource templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,11 @@ You have 2 different options to manage virtual hosts
   and it provides more flexibility in the management of virtual hosts and single location
   statements (with the nginx::resource::location define).
 
+* Templates used by nginx::resource can be overriden
+
+        nginx::resource::vhost { 'mydomain.com' :
+          www_root        => '/var/www/mydomain',
+          template_header => 'my_module/nginx/header.erb',
+        }
+
 [![Build Status](https://travis-ci.org/example42/puppet-nginx.png?branch=master)](https://travis-ci.org/example42/puppet-nginx)

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -35,6 +35,8 @@ define nginx::resource::location(
   $proxy_set_header   = ['Host $host', 'X-Real-IP $remote_addr', 'X-Forwarded-For $proxy_add_x_forwarded_for', 'X-Forwarded-Proto $scheme' ],
   $ssl                = false,
   $option             = undef,
+  $template_proxy     = 'nginx/vhost/vhost_location_proxy.erb',
+  $template_directory = 'nginx/vhost/vhost_location_directory.erb',
   $location
 ) {
   File {
@@ -52,9 +54,9 @@ define nginx::resource::location(
 
   # Use proxy template if $proxy is defined, otherwise use directory template.
   if ($proxy != undef) {
-    $content_real = template('nginx/vhost/vhost_location_proxy.erb')
+    $content_real = template("${template_proxy}")
   } else {
-    $content_real = template('nginx/vhost/vhost_location_directory.erb')
+    $content_real = template("${template_directory}")
   }
 
   ## Check for various error condtiions

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -20,7 +20,8 @@
 #    ],
 #  }
 define nginx::resource::upstream (
-  $ensure = 'present',
+  $ensure            = 'present',
+  $template_upstream = 'nginx/conf.d/upstream.erb',
   $members
 ) {
   File {
@@ -34,7 +35,7 @@ define nginx::resource::upstream (
       'absent' => absent,
       default  => 'file',
     },
-    content  => template('nginx/conf.d/upstream.erb'),
+    content  => template("${template_upstream}"),
     notify   => $nginx::manage_service_autorestart,
   }
 }


### PR DESCRIPTION
To follow the Open-Close principle which is already used in all example42 modules, the templates used in nginx::resource can now be overriden.
This modification should be completely backward compatible, but has only been lightly tested sofar.
