### PR TITLE
Showing the world our server version is an unnecessary security risk

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -11,6 +11,7 @@ events {
 }
 
 http {
+  server_tokens off
   include       <%= scope.lookupvar('nginx::config_dir')%>/mime.types;
   default_type  application/octet-stream;
 


### PR DESCRIPTION
An issue was raised at my company that we are exposing the nginx version to the world.
I believe it's best practise to switch this off, so that's what this pull request does.
