### PR TITLE
Typo in nginx.conf

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -11,7 +11,7 @@ events {
 }
 
 http {
-  server_tokens off
+  server_tokens off;
   include       <%= scope.lookupvar('nginx::config_dir')%>/mime.types;
   default_type  application/octet-stream;
 


### PR DESCRIPTION
Ciao Alessandro,

  just a typo, preventing nginx config to be loaded.

  Regards,
            Javier
