### PR TITLE
respect listen_ip setting from nginx::resource::vhost

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,7 +1,7 @@
 # File Managed by Puppet
 
 server {
-  listen <%= @listen_ip %>; 
+  listen <%= @listen_ip %><% if defined? @listen_port %>:<%= @listen_port %><% end %>; 
   <% # check to see if ipv6 support exists in the kernel before applying %>
   <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
   server_name <%= @server_name %>;

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,5 +1,5 @@
 server {
-  listen       443;
+  listen <% if defined? @listen_ip %><%= @listen_ip %>:<% end %>443;
   <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
   server_name  <%= @server_name %>;
 


### PR DESCRIPTION
Hope it is usable this way. I am not yet used generating pull requests.

The listen_port and listen_ip had not been regarded in the templates. 
