### PR TITLE
added option default_server to mark one server as the default.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -9,6 +9,8 @@
 #                          support exists on your system before enabling.
 #   [*ipv6_listen_ip*]   - Default IPv6 Address for NGINX to listen with this vHost on. Defaults to all interfaces (::)
 #   [*ipv6_listen_port*] - Default IPv6 Port for NGINX to listen with this vHost on. Defaults to TCP 80
+#   [*default_server*]   - BOOL value to mark this server as default server which is choosen if no hostname is given on the request.
+#                          Default: false. Example: default_server => 'true'
 #   [*index_files*]      - Default index files for NGINX to read when traversing a directory
 #   [*proxy*]            - Proxy server(s) for the root location to connect to.  Accepts a single value, can be used in
 #                          conjunction with nginx::resource::upstream
@@ -37,6 +39,7 @@ define nginx::resource::vhost(
   $ipv6_enable         = false,
   $ipv6_listen_ip      = '::',
   $ipv6_listen_port    = '80',
+  $default_server      = false,
   $server_name         = $name,
   $ssl                 = absent,
   $ssl_cert            = undef,

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,7 +1,7 @@
 # File Managed by Puppet
 
 server {
-  listen <%= @listen_ip %><% if defined? @listen_port %>:<%= @listen_port %><% end %>; 
+  listen <%= @listen_ip %><% if defined? @listen_port %>:<%= @listen_port %><% end %><% if @default_server == 'true' %> default_server<% end %>;
   <% # check to see if ipv6 support exists in the kernel before applying %>
   <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
   server_name <%= @server_name %>;

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,5 +1,5 @@
 server {
-  listen <% if defined? @listen_ip %><%= @listen_ip %>:<% end %>443;
+  listen <% if defined? @listen_ip %><%= @listen_ip %>:<% end %>443<% if @default_server == 'true' %> default_server<% end %>;
   <% if @ipv6_enable == 'true' && (defined? @ipaddress6) %>listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> default ipv6only=on;<% end %>
   server_name  <%= @server_name %>;
 


### PR DESCRIPTION
Default server are usefull if you have multiple named server and you want to control which content is delivered if no host is given in the request or an ip address is used for the request.

Eample usage:
  $defaultdir= '/var/lib/nginx/defaultpage'

  file { "${defaultdir}/index.html":
    mode   => '444',
    owner  => 'www-data',
    ensure => 'present',
    content => '<html><head><title>host not found</title></head><body><p>host not found</p></body></html>',
  }

  nginx::resource::vhost { $fqdn:
    ensure   => present,
    default_server  => 'true',
    www_root => $defaultdir,
  }
