### PR TITLE
Fixed trailing comma in location resource.

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -47,7 +47,7 @@ define nginx::resource::location(
   $template_proxy     = 'nginx/vhost/vhost_location_proxy.erb',
   $template_directory = 'nginx/vhost/vhost_location_directory.erb',
   $template_redirect  = 'nginx/vhost/vhost_location_redirect.erb',
-  $location           = $title,
+  $location           = $title
 ) {
   File {
     owner  => 'root',


### PR DESCRIPTION
To maintain compatibility with puppet 2.6.x
