### PR TITLE
Fix nginx config typo

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -22,7 +22,7 @@ http {
   tcp_nodelay        on;
   client_max_body_size <%= scope.lookupvar('nginx::client_max_body_size')%>;
   keepalive_timeout  <%= scope.lookupvar('nginx::keepalive_timeout')%>;
-  types_hash_max_size <%= scope.lookupvar('nginx::types_hash_max_size') %>)
+  types_hash_max_size <%= scope.lookupvar('nginx::types_hash_max_size') %>;
 
   gzip         <%= scope.lookupvar('nginx::real_gzip')%>;
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";


### PR DESCRIPTION
Fixes the following error:

```
$ sudo service nginx restart
Restarting nginx: nginx: [emerg] invalid number of arguments in "types_hash_max_size" directive in /etc/nginx/nginx.conf:27
```
