### PR TITLE
Use the default nginx.conf.erb template

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,7 +97,7 @@ class nginx::params {
   $source_dir = ''
   $source_dir_purge = false
   $config_file_default_purge = false
-  $template = ''
+  $template = 'nginx/conf.d/nginx.conf.erb'
   $options = ''
   $service_autorestart = true
   $version = 'present'


### PR DESCRIPTION
This template lets you customize a bunch of options and is functionally the same as the default `nginx.conf` file. Why is it not being used by default?
