### PR TITLE
Fix Debian configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -293,6 +293,11 @@ class nginx (
   }
 
   ### Calculation of variables that dependes on arguments
+  # Debian uses TWO configs dirs separatedly
+  $cdir = $::operatingsystem ? {
+    default => "${nginx::config_dir}/conf.d",
+  }
+
   $vdir = $::operatingsystem ? {
     /(?i:Ubuntu|Debian|Mint)/ => "${nginx::config_dir}/sites-available",
     default                   => "${nginx::config_dir}/conf.d",

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -77,10 +77,7 @@ define nginx::resource::location(
     default  => file,
   }
 
-  $file_real = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => "${nginx::config_dir}/sites-available/${vhost}.conf",
-    default                   => "${nginx::config_dir}/conf.d/${vhost}.conf",
-  }
+  $file_real = "${nginx::config_dir}/${nginx::vdir}/${vhost}.conf"
 
   # Use proxy template if $proxy is defined, otherwise use directory template.
   if ($proxy != undef) {

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -35,7 +35,7 @@ define nginx::resource::upstream (
     default  => file,
   }
 
-  file { "${nginx::config_dir}/conf.d/${name}-upstream.conf":
+  file { "${nginx::config_dir}/${nginx::cdir}/${name}-upstream.conf":
     ensure   => $real_file,
     content  => template($template_upstream),
     notify   => $nginx::manage_service_autorestart,

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -93,11 +93,12 @@ define nginx::resource::vhost(
     default => $groupowner,
   }
 
+  $file_real = "${nginx::config_dir}/${nginx::vdir}/${name}.conf"
+
   # Some OS specific settings:
   # On Debian/Ubuntu manages sites-enabled
   case $::operatingsystem {
     ubuntu,debian,mint: {
-      $file_real = "${nginx::config_dir}/sites-available/${name}.conf"
 
       $manage_file = $ensure ? {
         present => link,
@@ -112,7 +113,6 @@ define nginx::resource::vhost(
       }
     }
     redhat,centos,scientific,fedora: {
-      $file_real = "${nginx::config_dir}/conf.d/${name}.conf"
       # include nginx::redhat
     }
     default: { }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -83,6 +83,55 @@ describe 'nginx' do
   end 
 
   describe 'Test customizations - template' do
+    let(:facts) { { :operatingsystem => 'Debian', :processorcount => 8 } }
+    let(:params) do
+      { 
+        :template => "nginx/conf.d/nginx.conf.erb"
+      }
+    end
+    let(:expected) do
+'# File Managed by Puppet 
+user www-data;
+worker_processes 8;
+
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+  # 
+}
+
+http {
+  server_tokens off;
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log  /var/log/nginx/access.log;
+
+  sendfile    on;
+  #tcp_nopush  on;
+  tcp_nodelay        on;
+  client_max_body_size 10m;
+  keepalive_timeout  65;
+  types_hash_max_size 1024;
+
+  gzip         on;
+  gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+
+  include /etc/nginx/conf.d/*.conf;
+
+  include /etc/nginx/sites-available/*.conf;
+}
+'
+    end
+    it 'should generate a valid template' do
+       should contain_file('nginx.conf').with_content(expected)
+    end
+  end
+
+  describe 'Test customizations - use own template' do
     let(:params) { {:template => "nginx/spec.erb" , :options => { 'opt_a' => 'value_a' } } }
 
     it 'should generate a valid template' do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -27,5 +27,8 @@ http {
   gzip         <%= scope.lookupvar('nginx::real_gzip')%>;
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
 
+<% if scope.lookupvar('nginx::cdir') != '' %>
+  include <%= scope.lookupvar('nginx::cdir')%>/*.conf;
+<% end %>
   include <%= scope.lookupvar('nginx::vdir')%>/*.conf;
 }


### PR DESCRIPTION
Hi Al,

Debian uses **TWO** configuration dirs for nginx (`/etc/nginx/sites-available` **AND** `/etc/nginx/conf.d`), and only the former was being included in the main config. 

This raised an issue when setting upstreams with the `manifests::resource::upstream` define, as it writes them to `/etc/nginx/conf.d`. As it was not being included when runnning on a Debian host, nginx failed to start.

As a side efect, all hardcoded paths in the defines can now be handled better (not the best way for my taste, but the best I could find without making extensive changes in the module)

This patches also include a spec test to prevent breaking the main `nginx.conf` file with typos.
