### PR TITLE
Fix errors introduced with merge 4dd435e7e5b6f82bd776b7b07b1de62cbd1bdf11

### DIFF
--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -89,9 +89,46 @@ describe 'nginx' do
         :template => "nginx/conf.d/nginx.conf.erb"
       }
     end
+    let(:expected) do
+'# File Managed by Puppet 
+user www-data;
+worker_processes 8;
+
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+  # 
+}
+
+http {
+  server_tokens off;
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log  /var/log/nginx/access.log;
+
+  sendfile    on;
+  #tcp_nopush  on;
+  tcp_nodelay        on;
+  client_max_body_size 10m;
+  keepalive_timeout  65;
+  server_names_hash_bucket_size 64;
+  types_hash_max_size 1024;
+
+  gzip         on;
+  gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+
+  include /etc/nginx/conf.d/*.conf;
+
+  include /etc/nginx/sites-available/*.conf;
+}
+'
+    end
     it 'should generate a valid template' do
-      content = catalogue.resource('file', 'nginx.conf').send(:parameters)[:content]
-      content.should match "user www-data"
+      should contain_file('nginx.conf').with_content(expected)
     end
   end
 

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -31,10 +31,5 @@ http {
 <% if scope.lookupvar('nginx::cdir') != '' %>
   include <%= scope.lookupvar('nginx::cdir')%>/*.conf;
 <% end %>
-<% if scope.lookupvar('::operatingsystem') =~ /(?i:Ubuntu|Debian|Mint)/ %>
-  include <%= scope.lookupvar('nginx::config_dir') %>/conf.d/*.conf;
-  include <%= scope.lookupvar('nginx::config_dir') %>/sites-enabled/*;
-<% else %>
   include <%= scope.lookupvar('nginx::vdir')%>/*.conf;
-<% end %>
 }


### PR DESCRIPTION
Merge 4dd435e7e5b6f82bd776b7b07b1de62cbd1bdf11 (PR #39) fixed the same problem as PR #42, and was merged after #42. As a result, the config file got broken, probably due to a bad conflict resolution.

Also, as an side effect, the specs to test for a valid config file got deleted too.

This patch reverts those commits and restores the config file structure.
