### PR TITLE
Protect against Poodle

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -16,6 +16,6 @@ server {
 
   ssl_session_timeout  5m;
 
-  ssl_protocols  SSLv3 TLSv1;
+  ssl_protocols  TLSv1;
   ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
   ssl_prefer_server_ciphers   on;


### PR DESCRIPTION
SSLv3 protocol should no more be used due to the poodle exploit.

Regards,