### PR TITLE
vhost - additional parameter for expansion in user vhost template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -430,7 +430,7 @@ class nginx (
   }
 
   # The whole nginx configuration directory can be recursively overriden
-  if $nginx::source_dir {
+  if $nginx::source_dir != '' {
     file { 'nginx.dir':
       ensure  => directory,
       path    => $nginx::config_dir,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -6,6 +6,8 @@
 # - The $port to configure the host on
 # - The $docroot provides the Documentation Root variable
 # - The $template option specifies whether to use the default template or override
+# - The $options can be an array or hash variable that the custom
+#   template may use for expanding custom variables
 # - The $priority of the site
 # - The $serveraliases of the site
 #
@@ -26,6 +28,7 @@ define nginx::vhost (
   $docroot,
   $port           = '80',
   $template       = 'nginx/vhost/vhost.conf.erb',
+  $options        = undef,
   $priority       = '50',
   $serveraliases  = '',
   $create_docroot = true,

--- a/templates/vhost/vhost_redirect.erb
+++ b/templates/vhost/vhost_redirect.erb
@@ -1,0 +1,10 @@
+# Virtual host <%= @name %>
+# This file has been provided by puppet for <%= @fqdn %>.
+# DON'T EDIT it manually, any changes will be lost
+#
+
+server {
+  listen <%= @port %>;
+  server_name <%= @serveraliases.join(" ") %>;
+  return <% if @options['status_code'] then -%><%= @options['status_code'] -%><% else %>301<%- end -%> <%= @options['redirect_url'] %>$request_uri;
+}


### PR DESCRIPTION
- the 'options' parameter now allows for expanding arbitrary variables
  in user specified template vhost template. It is needed since vhost
  define expands the template.
- a sample template has been provided. It can be used for redirecting
  the entire server to different locations has
