### PR TITLE
Ensure => absent not remove vhost config file.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -123,7 +123,9 @@ define nginx::resource::vhost(
     default: { }
   }
 
-  concat { $file_real: }
+  concat { $file_real:
+    ensure => $ensure,
+  }
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.


### PR DESCRIPTION
Hi,

If ensure is set to present concat file should be ensured absent too.

This pull request force the deletation of the configuration file.

Regards